### PR TITLE
heroku deploy missing start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "cd server"
+    "build": "cd server",
+    "start": "node ./server/server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added a start script on the root directory, because Heroku is working from the root